### PR TITLE
fix(ci): grant explicit write permissions for GHCR (#173)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,10 +8,12 @@ on:
 
   workflow_dispatch:
 
-permissions: write-all
-
 jobs:
   build-and-push-images:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/terminal-docker.yml
     with:
       registry-url: ghcr.io


### PR DESCRIPTION
Explicitly defined 'packages: write' scope for the build-and-push-images job to resolve the 403 Forbidden error during docker compose publish in the organization.