### PR TITLE
fix(ci): migrate to koptoel registry and resolve ansible permission issues (#176)

### DIFF
--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           ANSIBLE_USER: ${{ secrets.ansible-user }}
           ANSIBLE_HOST_KEY_CHECKING: false
+          ANSIBLE_REMOTE_TMP: /tmp/.ansible/tmp
         run: |
           ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
             --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \

--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -39,4 +39,7 @@ jobs:
           ANSIBLE_USER: ${{ secrets.ansible-user }}
           ANSIBLE_HOST_KEY_CHECKING: false
         run: |
-          ansible-playbook -i inventory.ini ansible/deploy-playbook.yml --private-key private_key.pem -u ${{ secrets.ansible-user }}
+          run: |
+          ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
+            --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \
+            --private-key private_key.pem -u ${{ secrets.ansible-user }}

--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -38,9 +38,17 @@ jobs:
         env:
           ANSIBLE_USER: ${{ secrets.ansible-user }}
           ANSIBLE_HOST_KEY_CHECKING: false
+          # Te zmienne zmuszają Pythona i Ansible do użycia Twojego Home zamiast systemowego /tmp
+          TMPDIR: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
+          TEMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
+          TMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
+          ANSIBLE_REMOTE_TMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           ANSIBLE_PIPELINING: "True"
-          ANSIBLE_REMOTE_TMP: "~/.ansible/tmp"
         run: |
+          # 1. Ręcznie tworzymy folder przez SSH zanim Ansible wystartuje
+          ssh -o StrictHostKeyChecking=no -p 50022 ${{ secrets.ansible-user }}@153.19.51.139 "mkdir -p ~/.ansible_tmp && chmod 700 ~/.ansible_tmp"
+          
+          # 2. Odpalamy Ansible
           ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
             --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \
-            --private-key private_key.pem -u ${{ secrets.ansible-user }} -vvv
+            --private-key private_key.pem -u ${{ secrets.ansible-user }}

--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -38,8 +38,9 @@ jobs:
         env:
           ANSIBLE_USER: ${{ secrets.ansible-user }}
           ANSIBLE_HOST_KEY_CHECKING: false
-          ANSIBLE_REMOTE_TMP: /tmp/.ansible_terminal_${{ github.run_id }}
+          ANSIBLE_PIPELINING: "True"
+          ANSIBLE_REMOTE_TMP: "~/.ansible/tmp"
         run: |
           ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
             --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \
-            --private-key private_key.pem -u ${{ secrets.ansible-user }}
+            --private-key private_key.pem -u ${{ secrets.ansible-user }} -vvv

--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -33,12 +33,12 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y ansible
-
+          
       - name: Run Ansible Playbook
         env:
           ANSIBLE_USER: ${{ secrets.ansible-user }}
           ANSIBLE_HOST_KEY_CHECKING: false
-          ANSIBLE_REMOTE_TMP: /tmp/.ansible/tmp
+          ANSIBLE_REMOTE_TMP: /tmp/.ansible_terminal_${{ github.run_id }}
         run: |
           ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
             --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \

--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -39,7 +39,6 @@ jobs:
           ANSIBLE_USER: ${{ secrets.ansible-user }}
           ANSIBLE_HOST_KEY_CHECKING: false
         run: |
-          run: |
           ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
             --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \
             --private-key private_key.pem -u ${{ secrets.ansible-user }}

--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -43,8 +43,12 @@ jobs:
           TMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           ANSIBLE_REMOTE_TMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           ANSIBLE_PIPELINING: "True"
+          
         run: |
-          ssh -o StrictHostKeyChecking=no -p 50022 -i private_key.pem ${{ secrets.ansible-user }}@153.19.51.139 "mkdir -p ~/.ansible_tmp && chmod 700 ~/.ansible_tmp"        
+          ssh -o StrictHostKeyChecking=no -p 50022 -i private_key.pem ${{ secrets.ansible-user }}@153.19.51.139 "mkdir -p ~/.ansible_tmp && chmod 700 ~/.ansible_tmp"
+          
           ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
             --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \
+            --extra-vars "registry_token=${{ secrets.GITHUB_TOKEN }}" \
+            --extra-vars "github_user=${{ github.actor }}" \
             --private-key private_key.pem -u ${{ secrets.ansible-user }}

--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -28,8 +28,9 @@ jobs:
           host-list: ${{ secrets.deployment-targets }}
           group-name: web
 
+      # Ansible jest preinstalowany na ubuntu-latest, 
+      # ale zostawiamy, jeśli chcesz konkretną wersję z apt
       - name: Install Ansible
-        shell: bash
         run: |
           sudo apt update
           sudo apt install -y ansible
@@ -38,6 +39,7 @@ jobs:
         env:
           ANSIBLE_USER: ${{ secrets.ansible-user }}
           ANSIBLE_HOST_KEY_CHECKING: false
+          # Zmienne TMPDIR zostają, bo uratowały nam skórę przy błędach dysku
           TMPDIR: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           TEMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           TMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
@@ -45,10 +47,15 @@ jobs:
           ANSIBLE_PIPELINING: "True"
           
         run: |
-          ssh -o StrictHostKeyChecking=no -p 50022 -i private_key.pem ${{ secrets.ansible-user }}@153.19.51.139 "mkdir -p ~/.ansible_tmp && chmod 700 ~/.ansible_tmp"
+          # Używamy zmiennej zamiast twardego IP
+          ssh -o StrictHostKeyChecking=no -p 50022 -i private_key.pem ${{ secrets.ansible-user }}@${{ secrets.deployment-targets }} "mkdir -p ~/.ansible_tmp && chmod 700 ~/.ansible_tmp"
           
           ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
             --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \
             --extra-vars "registry_token=${{ secrets.GITHUB_TOKEN }}" \
             --extra-vars "github_user=${{ github.actor }}" \
             --private-key private_key.pem -u ${{ secrets.ansible-user }}
+
+      - name: Cleanup
+        if: always()
+        run: rm -f private_key.pem

--- a/.github/workflows/terminal-ansible.yml
+++ b/.github/workflows/terminal-ansible.yml
@@ -38,17 +38,13 @@ jobs:
         env:
           ANSIBLE_USER: ${{ secrets.ansible-user }}
           ANSIBLE_HOST_KEY_CHECKING: false
-          # Te zmienne zmuszają Pythona i Ansible do użycia Twojego Home zamiast systemowego /tmp
           TMPDIR: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           TEMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           TMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           ANSIBLE_REMOTE_TMP: "/home/${{ secrets.ansible-user }}/.ansible_tmp"
           ANSIBLE_PIPELINING: "True"
         run: |
-          # 1. Ręcznie tworzymy folder przez SSH zanim Ansible wystartuje
-          ssh -o StrictHostKeyChecking=no -p 50022 ${{ secrets.ansible-user }}@153.19.51.139 "mkdir -p ~/.ansible_tmp && chmod 700 ~/.ansible_tmp"
-          
-          # 2. Odpalamy Ansible
+          ssh -o StrictHostKeyChecking=no -p 50022 -i private_key.pem ${{ secrets.ansible-user }}@153.19.51.139 "mkdir -p ~/.ansible_tmp && chmod 700 ~/.ansible_tmp"        
           ansible-playbook -i inventory.ini ansible/deploy-playbook.yml \
             --extra-vars "compose_image=oci://ghcr.io/${{ github.repository_owner }}/terminal/compose:latest" \
             --private-key private_key.pem -u ${{ secrets.ansible-user }}

--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -6,13 +6,17 @@
       stat:
         path: .env
       register: file_check
+
     - name: Fail if .env does not exist
       fail:
-        msg: "Create .env file! For reference see https://github.com/FlaviusAugustus/TERMINAL/blob/main/.env.sample.local"
+        msg: "Create .env file! For reference see https://github.com/koptoel/TERMINAL/blob/main/.env.sample.local"
       when: not file_check.stat.exists
+
     - name: Docker compose down
-      shell: docker compose --env-file .env -f oci://ghcr.io/flaviusaugustus/terminal/compose:latest down
+      shell: "docker compose --env-file .env -f {{ compose_image }} down"
+
     - name: Docker compose pull
-      shell: docker compose --env-file .env -f oci://ghcr.io/flaviusaugustus/terminal/compose:latest pull
+      shell: "docker compose --env-file .env -f {{ compose_image }} pull"
+
     - name: Docker compose up
-      shell: docker compose --env-file .env -f oci://ghcr.io/flaviusaugustus/terminal/compose:latest up -yd
+      shell: "docker compose --env-file .env -f {{ compose_image }} up -yd"

--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -2,6 +2,11 @@
   hosts: all
 
   tasks:
+
+    - name: Log into GitHub Container Registry
+      shell: "echo {{ registry_token }} | docker login ghcr.io -u {{ github_user }} --password-stdin"
+      no_log: true 
+  
     - name: Check if .env file exists
       stat:
         path: .env

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,12 +1,12 @@
 name: terminal.prod
 services:
   client:
-    image: ghcr.io/flaviusaugustus/terminal/client:latest
+    image: ghcr.io/koptoel/terminal/client:latest
     ports:
       - 60005:5173
 
   server:
-    image: ghcr.io/flaviusaugustus/terminal/server:latest
+    image: ghcr.io/koptoel/terminal/server:latest
     ports:
       - 60004:5006
     environment:


### PR DESCRIPTION
This PR resolves deployment failures on the `opto` server and completes the migration to the `koptoel` organization.

### Key Changes:
- **Registry Migration**: Updated OCI image paths in `compose.prod.yaml` to the new organization.
- **GHCR Authentication**: Added a `docker login` task to the Ansible playbook to resolve 401 Unauthorized errors.
- **Permission Workaround**: Implemented a custom `TMPDIR` (`~/.ansible_tmp`) to bypass restricted access to the system `/tmp` directory.
- **CI/CD Fixes**: Corrected workflow syntax and ensured remote directory initialization via SSH.

**Closes:** #176