### PR TITLE
feat(monitoring): integrate OpenTelemetry with EF Core for #179

### DIFF
--- a/Server/src/Terminal.Backend.Api/Terminal.Backend.Api.csproj
+++ b/Server/src/Terminal.Backend.Api/Terminal.Backend.Api.csproj
@@ -17,6 +17,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
     </ItemGroup>
 

--- a/Server/src/Terminal.Backend.Api/appsettings.json
+++ b/Server/src/Terminal.Backend.Api/appsettings.json
@@ -9,12 +9,10 @@
   "LogFile": "terminal.log",
   "Invitations": {
     "LinkBase": "https://terminal-client.dev/api/invitations/accept"
-  }
-  {
-    "HyperDX": {
-      "ServiceName": "terminal-backend",
-      "Endpoint": "http://153.19.51.139:40001/v1/traces",
-      "ApiKey": "a0606250-55d3-435a-9e29-30ac7b3ae0d4"
-    }
+  },
+  "HyperDX": {
+    "ServiceName": "terminal-backend",
+    "Endpoint": "http://153.19.51.139:40001/v1/traces",
+    "ApiKey": "a0606250-55d3-435a-9e29-30ac7b3ae0d4"
   }
 }

--- a/Server/src/Terminal.Backend.Api/appsettings.json
+++ b/Server/src/Terminal.Backend.Api/appsettings.json
@@ -10,4 +10,11 @@
   "Invitations": {
     "LinkBase": "https://terminal-client.dev/api/invitations/accept"
   }
+  {
+    "HyperDX": {
+      "ServiceName": "terminal-backend",
+      "Endpoint": "http://153.19.51.139:40001/v1/traces",
+      "ApiKey": "a0606250-55d3-435a-9e29-30ac7b3ae0d4"
+    }
+  }
 }

--- a/Server/src/Terminal.Backend.Infrastructure/Extensions.cs
+++ b/Server/src/Terminal.Backend.Infrastructure/Extensions.cs
@@ -1,3 +1,6 @@
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Exporter;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -29,6 +32,28 @@ public static class Extensions
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
+        // --- START: HyperDX & OpenTelemetry ---
+        var serviceName = configuration["HyperDX:ServiceName"] ?? "terminal-backend";
+        var hdxEndpoint = configuration["HyperDX:Endpoint"];
+        var hdxApiKey = configuration["HyperDX:ApiKey"];
+
+        if (!string.IsNullOrEmpty(hdxEndpoint) && !string.IsNullOrEmpty(hdxApiKey))
+        {
+            services.AddOpenTelemetry()
+                .WithTracing(tracing => tracing
+                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName))
+                    .AddSource(serviceName)
+                    .AddAspNetCoreInstrumentation() // Œledzenie ¿¹dañ przychodz¹cych do API
+                    .AddHttpClientInstrumentation() // Œledzenie ¿¹dañ wychodz¹cych
+                    .AddEntityFrameworkCoreInstrumentation() // Œledzenie zapytañ do PostgreSQL!
+                    .AddOtlpExporter(options =>
+                    {
+                        options.Endpoint = new Uri(hdxEndpoint);
+                        options.Headers = $"Authorization={hdxApiKey}";
+                        options.Protocol = OtlpExportProtocol.HttpProtobuf;
+                    }));
+        }
+        // --- KONIEC: HyperDX ---
         services.AddControllers();
         services.AddSingleton<ExceptionMiddleware>();
         services.AddHttpContextAccessor();

--- a/Server/src/Terminal.Backend.Infrastructure/Terminal.Backend.Infrastructure.csproj
+++ b/Server/src/Terminal.Backend.Infrastructure/Terminal.Backend.Infrastructure.csproj
@@ -9,6 +9,11 @@
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.12" />    
         <PackageReference Include="Serilog" Version="4.2.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />


### PR DESCRIPTION
## Summary
Implemented OpenTelemetry instrumentation for the TERMINAL backend to enable full observability via HyperDX.

## Changes
- Added OpenTelemetry NuGet packages (Core, AspNetCore, HTTP, and EF Core).
- Updated `Infrastructure.Extensions` to include OTel tracing configuration.
- Configured OTLP exporter to send data to the Gdańsk collector (`153.19.51.139`).
- Added HyperDX configuration section to `appsettings.json`.

## Impact
Once merged, the Ansible workflow will deploy these changes, and the backend will start reporting traces (including SQL queries) to the HyperDX dashboard.

**Closes #179**